### PR TITLE
Add stroke-order animation, dictionary loading screen, and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Nick Williams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MMM-Kanji-Random.css
+++ b/MMM-Kanji-Random.css
@@ -12,6 +12,24 @@
   color: orange;
 }
 
+.MMM-Kanji-Random .stroke-box {
+  margin: 0 4px;
+  vertical-align: middle;
+}
+
+.MMM-Kanji-Random.loading .kanji {
+  opacity: 0.6;
+}
+
+.MMM-Kanji-Random.loading .definition {
+  animation: mmm-kanji-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes mmm-kanji-pulse {
+  0%, 100% { opacity: 0.3; }
+  50%      { opacity: 0.8; }
+}
+
 .MMM-Kanji-Random ul {
   list-style-type: none;
   padding-left: 0px;
@@ -32,5 +50,10 @@
 .MMM-Kanji-Random .definition {
   font-size: 12pt;
   font-weight: light;
+}
+
+.MMM-Kanji-Random .lookup-error {
+  color: #ff6b6b;
+  font-style: italic;
 }
 

--- a/MMM-Kanji-Random.js
+++ b/MMM-Kanji-Random.js
@@ -11,13 +11,30 @@
 Module.register('MMM-Kanji-Random',{
     
     defaults: {
-        minsBeforeChange: 60, // update once an hour
-        maxDefinitions: 4
+        level: "N5",                  // JLPT level of vocabulary to show (N1-N5)
+        minsBeforeChange: 60,         // update once an hour
+        maxDefinitions: 4,            // max dictionary senses to display
+        dictTimeout: 8000,            // ms to wait for the dictionary lookup before giving up
+        animateStrokeOrder: true,     // animate kanji stroke order with HanziWriter
+        strokeSize: 80,               // px size of each animated character
+        strokeAnimationSpeed: 1,      // 1 = normal, >1 = faster
+        strokeDelay: 400,             // ms pause between strokes
+        strokeLoopDelay: 2000,        // ms pause before the animation loops
+        strokeColor: '#ffffff',       // color of drawn strokes
+        strokeOutlineColor: '#444444', // color of the character outline
+        strokeUncommonColor: 'orange' // stroke color used for uncommon kanji
     },
 
     getStyles: function() {
         return ['MMM-Kanji-Random.css'];
-    },    
+    },
+
+    getScripts: function() {
+        if (this.config.animateStrokeOrder) {
+            return ['https://cdn.jsdelivr.net/npm/hanzi-writer@3/dist/hanzi-writer.min.js'];
+        }
+        return [];
+    },
 
     start: function() {
         Log.log(this.name + ': Starting module');
@@ -30,6 +47,24 @@ Module.register('MMM-Kanji-Random',{
         setInterval(function() {
             self.sendSocketNotification('START', request);
         }, self.config.minsBeforeChange * 1000 * 60);
+
+        // The HanziWriter script loads asynchronously. Once it's available,
+        // re-render so the loading screen switches to the animated kanji. If it
+        // never loads (e.g. CDN unreachable), give up and fall back to plain text.
+        if (self.config.animateStrokeOrder) {
+            var attempts = 0;
+            self._scriptCheck = setInterval(function() {
+                if (typeof HanziWriter !== "undefined") {
+                    clearInterval(self._scriptCheck);
+                    self.updateDom();
+                } else if (++attempts >= 50) { // ~10s
+                    clearInterval(self._scriptCheck);
+                    self._scriptFailed = true;
+                    Log.warn(self.name + ": HanziWriter failed to load; showing plain text");
+                    self.updateDom();
+                }
+            }, 200);
+        }
     },
 
     getDom: function() {
@@ -37,64 +72,238 @@ Module.register('MMM-Kanji-Random',{
 
         var wrapper = document.createElement("div");
         wrapper.className = "medium";
-        if (this.kanji == null) {
-            return wrapper;
+
+        var animate = this.config.animateStrokeOrder && typeof HanziWriter !== "undefined";
+
+        // Show a loading screen until everything needed for the first clean
+        // switch is ready: the first kanji, the HanziWriter script (when
+        // animating), and the first dictionary lookup (or its timeout). This
+        // avoids showing partially-populated content as the pieces stream in.
+        var waitingForScript = this.config.animateStrokeOrder &&
+                               typeof HanziWriter === "undefined" &&
+                               !this._scriptFailed;
+        if (this.kanji == null || waitingForScript || !this._firstPaintReady) {
+            return this.getLoadingDom(wrapper);
         }
 
         var furigana = document.createElement("div");
         furigana.className = "furigana";
-        furigana.innerHTML = this.furigana;
+        furigana.textContent = this.furigana;
         wrapper.appendChild(furigana)
 
-        var kanji = document.createElement("div");
-        kanji.className = "kanji bright";
-        kanji.innerHTML = this.kanji;
+        var kanji;
+        if (animate && this._kanjiNode && this._kanjiWord === this.kanji) {
+            // Reuse the already-animating node so the dictionary update doesn't restart it
+            kanji = this._kanjiNode;
+        } else {
+            kanji = document.createElement("div");
+            kanji.className = "kanji bright";
+            if (animate) {
+                this.renderStrokeOrder(kanji, this.kanji);
+            } else {
+                kanji.textContent = this.kanji;
+            }
+            this._kanjiNode = animate ? kanji : null;
+            this._kanjiWord = this.kanji;
+        }
         wrapper.appendChild(kanji);
 
-        if (this.dict == null) {
-            // basic description we got from the core random kanji site
-            var definition = document.createElement("ul");
-            definition.className = "definition dim";
-            definition.innerHTML = this.definition;
-            wrapper.appendChild(definition);
+        var definition = document.createElement("div");
+        definition.className = "definition dim";
+        var senses = document.createElement("ul");
 
-        } else {
-            // more interesting description we got from the dictionary
-            var core = this.dict.data[0];
-            if (!core.is_common) {
-                kanji.className = "uncommon kanji"
-            }
+        var core = this.dict && this.dict.data ? this.dict.data[0] : null;
+        if (core) {
+            // richer definition from the dictionary lookup
+            this.applyUncommon(kanji, animate, !core.is_common);
 
-            var definition = document.createElement("div");
-            definition.className = 'definition dim';
-            var senses = document.createElement("ul");
-            core.senses.forEach(function(sense) {
+            core.senses.slice(0, this.config.maxDefinitions).forEach(function(sense) {
                 var li = document.createElement("li");
-                var text = sense.parts_of_speech.join(", ") + ": ";
-                text = text + sense.english_definitions.join(", ");
-                li.innerHTML = text;
+                li.textContent = sense.parts_of_speech.join(", ") + ": " +
+                                 sense.english_definitions.join(", ");
                 senses.appendChild(li);
             });
-            definition.appendChild(senses);
-            wrapper.appendChild(definition);
+        } else {
+            // No dictionary entry (yet): show the local vocabulary definition
+            var li = document.createElement("li");
+            li.textContent = this.definition;
+            senses.appendChild(li);
+
+            // Make the failure visible to the user, not just in the logs
+            if (this.dictTimedOut) {
+                var err = document.createElement("li");
+                err.className = "lookup-error";
+                err.textContent = "⚠ Dictionary lookup timed out";
+                senses.appendChild(err);
+            } else if (this.dict) {
+                var none = document.createElement("li");
+                none.className = "lookup-error";
+                none.textContent = "⚠ No dictionary entry found";
+                senses.appendChild(none);
+            }
         }
 
+        definition.appendChild(senses);
+        wrapper.appendChild(definition);
+
         return wrapper;
+    },
+
+    // Loading / splash screen shown before the first kanji (and script) are ready.
+    getLoadingDom: function(wrapper) {
+        wrapper.className = "medium loading";
+
+        var logo = document.createElement("div");
+        logo.className = "kanji bright";
+        logo.textContent = "漢字";
+        wrapper.appendChild(logo);
+
+        var message = document.createElement("div");
+        message.className = "definition dim";
+        message.textContent = "Loading…";
+        wrapper.appendChild(message);
+
+        return wrapper;
+    },
+
+    // Highlight an uncommon kanji: recolor the live strokes when animating,
+    // otherwise fall back to the CSS class used for plain text.
+    applyUncommon: function(kanji, animate, uncommon) {
+        if (!uncommon) { return; }
+        if (animate && this._strokeWriters) {
+            var color = this.config.strokeUncommonColor;
+            this._strokeWriters.forEach(function(w) {
+                w.updateColor("strokeColor", color);
+            });
+        } else {
+            kanji.className = "uncommon kanji";
+        }
+    },
+
+    // Stroke data is only available for kanji (CJK Unified Ideographs).
+    // Kana and other characters have no animation, so we render them as plain text.
+    isKanji: function(ch) {
+        var code = ch.codePointAt(0);
+        return (code >= 0x4E00 && code <= 0x9FFF) ||   // CJK Unified Ideographs
+               (code >= 0x3400 && code <= 0x4DBF);     // CJK Extension A
+    },
+
+    renderStrokeOrder: function(container, word) {
+        var self = this;
+        // Bump the generation so any sequence from a previous word stops looping
+        var generation = (this._strokeGeneration || 0) + 1;
+        this._strokeGeneration = generation;
+
+        var writers = [];
+        // Array.from splits the word into individual characters
+        Array.from(word).forEach(function(ch) {
+            var box = document.createElement("div");
+            box.className = "stroke-box";
+            box.style.display = "inline-block";
+            container.appendChild(box);
+
+            var size = self.config.strokeSize;
+            box.style.width = size + "px";
+            box.style.height = size + "px";
+
+            if (!self.isKanji(ch)) {
+                // Kana / punctuation: show immediately, no animation,
+                // sized and centred to line up with the animated kanji
+                box.textContent = ch;
+                box.style.lineHeight = size + "px";
+                box.style.fontSize = Math.round(size * 0.7) + "px";
+                box.style.textAlign = "center";
+                return;
+            }
+
+            var writer = HanziWriter.create(box, ch, {
+                width: size,
+                height: size,
+                padding: 4,
+                showOutline: true,
+                strokeColor: self.config.strokeColor,
+                outlineColor: self.config.strokeOutlineColor,
+                strokeAnimationSpeed: self.config.strokeAnimationSpeed,
+                delayBetweenStrokes: self.config.strokeDelay,
+                charDataLoader: function(char, onLoad, onError) {
+                    fetch("https://cdn.jsdelivr.net/npm/hanzi-writer-data-jp@0/" +
+                          encodeURIComponent(char) + ".json")
+                        .then(function(res) {
+                            if (!res.ok) { throw new Error("no stroke data"); }
+                            return res.json();
+                        })
+                        .then(onLoad)
+                        .catch(onError);
+                },
+                onLoadCharDataError: function() {
+                    // No stroke data (e.g. some kana): fall back to the plain character
+                    box.textContent = ch;
+                }
+            });
+
+            writers.push(writer);
+        });
+
+        this._strokeWriters = writers;
+        if (writers.length > 0) {
+            this.animateSequence(writers, generation);
+        }
+    },
+
+    // Animate each kanji in turn, starting the next once the previous completes,
+    // then pause and loop. Stops if a newer word has been rendered.
+    animateSequence: function(writers, generation) {
+        var self = this;
+
+        var step = function(i) {
+            if (self._strokeGeneration !== generation) { return; }
+            if (i >= writers.length) {
+                setTimeout(start, self.config.strokeLoopDelay);
+                return;
+            }
+            writers[i].animateCharacter({
+                onComplete: function() { step(i + 1); }
+            });
+        };
+
+        var start = function() {
+            if (self._strokeGeneration !== generation) { return; }
+            writers.forEach(function(w) { w.hideCharacter({ duration: 0 }); });
+            step(0);
+        };
+
+        start();
     },
 
     socketNotificationReceived: function(notification, payload) {
         Log.log(this.name + ": Received " + notification + " from node helper")
         if (notification == "KANJI_RESULT") {
             this.kanji      = payload.kanji;
-            this.definition = payload.definition;
+            this.definition = payload.description;
             this.furigana   = payload.furigana;
 
             this.dict = null;
+            this.dictTimedOut = false;
+
+            // Wait for the dictionary lookup, but don't wait forever: after the
+            // timeout, show the kanji anyway with a visible error.
+            var self = this;
+            clearTimeout(this._dictTimer);
+            this._dictTimer = setTimeout(function() {
+                self.dictTimedOut = true;
+                self._firstPaintReady = true;
+                Log.warn(self.name + ": dictionary lookup timed out for " + self.kanji);
+                self.updateDom();
+            }, this.config.dictTimeout);
+
             this.updateDom();
         }
 
         if (notification == "DICT_RESULT") {
+            clearTimeout(this._dictTimer);
             this.dict = payload;
+            this.dictTimedOut = false;
+            this._firstPaintReady = true;
             this.updateDom();
         }
     }

--- a/README.md
+++ b/README.md
@@ -47,8 +47,18 @@ The following properties can be configured:
 
 | **Option** | **Values** | **Description** |
 |---|---|---|
-| level | N1-N5 | Sets the difficulty/commonality of the vocabulary. N5 is the simplest. N1 is more advanced. Only words of the given rating will be shown. |
+| level | N1-N5 | Sets the difficulty/commonality of the vocabulary. N5 is the simplest. N1 is more advanced. Only words of the given rating will be shown. Defaults to N5. |
 | minsBeforeChange | 60 | How many minutes before the Kanji is changed. The default is 60 (i.e. hourly). |
+| maxDefinitions | 4 | Maximum number of dictionary definitions (senses) to display. |
+| dictTimeout | 8000 | Milliseconds to wait for the jisho.org dictionary lookup before giving up. On the first load the module shows a loading screen until the lookup completes; if it times out, the kanji is shown with a visible "Dictionary lookup timed out" message. |
+| animateStrokeOrder | true | Animate the stroke order of each character using [HanziWriter](https://chanind.github.io/hanzi-writer/) with KanjiVG data. Requires an internet connection (scripts/data are loaded from the jsDelivr CDN). Characters without stroke data (e.g. some kana) fall back to plain text. |
+| strokeSize | 80 | Size in pixels of each animated character. |
+| strokeAnimationSpeed | 1 | Animation speed. 1 is normal; higher is faster. |
+| strokeDelay | 400 | Milliseconds to pause between strokes. |
+| strokeLoopDelay | 2000 | Milliseconds to pause before the animation loops. |
+| strokeColor | "#ffffff" | Colour of the drawn strokes. |
+| strokeOutlineColor | "#444444" | Colour of the character outline shown before/under the strokes. |
+| strokeUncommonColor | "orange" | Stroke colour used when the kanji is flagged as uncommon by the dictionary. |
 
 
 ## Source

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,7 +6,6 @@
  */
 
 const NodeHelper = require("node_helper");
-const request = require("request");
 const sync = require("csv-parse/sync");
 const name = "MMM-Kanji-Random";
 const fs = require("fs");
@@ -66,21 +65,22 @@ module.exports = NodeHelper.create({
         self.sendSocketNotification('KANJI_RESULT', reply)
 
         // and asynchronously, go lookup the definition of the kanji
-        url = new URL("http://jisho.org/api/v1/search/words?keyword=" + glyph);
+        url = new URL("https://jisho.org/api/v1/search/words?keyword=" + glyph);
         console.log(name + ": kanji random is requesting " + url);
-        request({url:url, method:'GET'}, function(err, resp, content) {
-            if (!err && resp.statusCode == 200) {
-                json = JSON.parse(content);
-                self.sendSocketNotification('DICT_RESULT', json)
-                console.log(name + ": successfully looked up dictionary entry")
-            } else {
-                if (err) {
-                    console.log(name + ": dictionary error " + err);
-                } else {
-                    console.log(name + ": dictionary bad response " + resp.statusCode);
+        fetch(url, { method: 'GET' })
+            .then(function(resp) {
+                if (!resp.ok) {
+                    throw new Error("bad response " + resp.status);
                 }
-            };
-        });
+                return resp.json();
+            })
+            .then(function(json) {
+                self.sendSocketNotification('DICT_RESULT', json);
+                console.log(name + ": successfully looked up dictionary entry");
+            })
+            .catch(function(err) {
+                console.log(name + ": dictionary error " + err);
+            });
     },
 });
  


### PR DESCRIPTION
- Add MIT LICENSE file
- Replace deprecated 'request' dependency with built-in fetch in node_helper
- Animate kanji stroke order using HanziWriter + KanjiVG data (configurable)
- Render multi-kanji words sequentially with looping animation
- Recolor strokes for uncommon kanji
- Add loading screen that waits for the first dictionary lookup, with a visible timeout/error message and graceful fallback to plain text
- Fix definition field mismatch (payload.description) that showed 'undefined'
- Add level default, apply maxDefinitions, use textContent instead of innerHTML

Amp-Thread-ID: https://ampcode.com/threads/T-019ee803-9a29-749a-844f-86933d15ad6b